### PR TITLE
Add ability to create new wallets and specify wallet name for wallet methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -715,6 +715,12 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
+    "@types/url-join": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-4.0.0.tgz",
+      "integrity": "sha512-awrJu8yML4E/xTwr2EMatC+HBnHGoDxc2+ImA9QyeUELI1S7dOCIZcyjki1rkwoA8P2D2NVgLAJLjnclkdLtAw==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "15.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
@@ -4367,6 +4373,11 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/jest": "25.2.1",
     "@types/lodash": "4.14.149",
     "@types/node": "12.12.35",
+    "@types/url-join": "^4.0.0",
     "jest": "25.3.0",
     "ts-jest": "25.4.0",
     "typescript": "3.8.3"
@@ -28,6 +29,7 @@
     "delay": "4.3.0",
     "fp-ts": "2.5.3",
     "io-ts": "2.2.0",
-    "lodash": "4.17.15"
+    "lodash": "4.17.15",
+    "url-join": "^4.0.1"
   }
 }

--- a/src/BitcoinJsonRpc.ts
+++ b/src/BitcoinJsonRpc.ts
@@ -520,4 +520,15 @@ export default class BitcoinJsonRpc {
       return false;
     }
   }
+
+  // https://bitcoin-rpc.github.io/en/doc/0.17.99/rpc/wallet/createwallet/
+  public async createWallet(walletName: string, disablePrivateKeys: boolean = false) {
+    const args: any[] = [walletName];
+
+    if (disablePrivateKeys !== undefined) {
+      args.push(disablePrivateKeys);
+    }
+
+    return this.cmdWithRetryAndDecode(decoders.CreateWalletDecoder, 'createwallet', null, ...args);
+  }
 }

--- a/src/decoders.ts
+++ b/src/decoders.ts
@@ -292,3 +292,10 @@ export const ListUnspentDecoder = t.array(
 export type ListUnspentResult = t.TypeOf<typeof ListUnspentDecoder>;
 
 export const DumpPrivateKeyDecoder = t.string;
+
+export const CreateWalletDecoder = t.type({
+  name: t.string,
+  warning: t.union([t.string, t.undefined]),
+});
+
+export type CreateWalletResult = t.TypeOf<typeof CreateWalletDecoder>;


### PR DESCRIPTION
Exploring ideas around #1 

Contents:
1. Extend the private `BitcoinJsonRpc` class methods with an ability to specify the path for JSON-RPC requests
2. Make sure all public methods use the new signature for private methods internally
3. Implement the `createWallet` method for wallet creation
4. Overload most wallet methods with an "argument object" variants that accept an optional wallet name
5. Fit the wallet name into the rest of the wallet methods in an appropriate backward-compatible manner

Basically, I failed to create a lean implementation :)

The backward compatibility was not an obsession here, this is just the smallest changeset that I could come up with, within my couple of free hours. Anytime I tried to modify the module in a more radical way, it always came to be basically a ground-up rewrite, just retaining some initial ideas, and that is not what I wanted for now.

Totally ok with not merging this.